### PR TITLE
Add required providers block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    consul = {
+      source = "hashicorp/consul"
+      version = "2.11.0"
+    }
+  }
+}
+
 provider "consul" {
   address    = "localhost:8500"
   datacenter = "dc1"


### PR DESCRIPTION
Add required providers block, which updates this configuration for Terraform 0.14