### PR TITLE
[DNM] v2 exported services demo config

### DIFF
--- a/consul-playground/agent/Dockerfile
+++ b/consul-playground/agent/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM consul:latest
+FROM hashicorppreview/consul-enterprise:1.18-dev
 
 COPY . /etc/consul.d

--- a/consul-playground/docker-compose.yml
+++ b/consul-playground/docker-compose.yml
@@ -7,6 +7,10 @@ services:
   # consul client agents
   consul-agent-1: &consul-agent
     build: ./agent
+    environment:
+      CONSUL_LICENSE_PATH: /run/secrets/license
+    secrets:
+      - license
     networks:
       - consul-demo
     command: "agent -retry-join consul-server-bootstrap -client 0.0.0.0 --config-file /etc/consul.d/default.json"
@@ -18,6 +22,10 @@ services:
   consul-server-1: &consul-server
     <<: *consul-agent
     build: ./server
+    environment:
+      CONSUL_LICENSE_PATH: /run/secrets/license
+    secrets:
+      - license
     command: "agent -server -retry-join consul-server-bootstrap -client 0.0.0.0  --config-file /etc/consul.d/default.json"
 
   consul-server-2:
@@ -60,6 +68,10 @@ services:
       PORT: 9001
     networks:
       - consul-demo
-  
+
+secrets:
+  license:
+    file: ../../consul.lic
+
 networks:
   consul-demo:

--- a/consul-playground/main.tf
+++ b/consul-playground/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     consul = {
       source = "hashicorp/consul"
-      version = "2.14.0"
+      version = "2.20.0"
     }
   }
 }
@@ -17,5 +17,117 @@ provider "consul" {
   datacenter = "dc1"
 
   # SecretID from the previous step
-  token      = "YOUR_BOOTSTRAP_TOKEN_HERE"
+  token      = "<SECRED_ID_HERE>"
+}
+
+# Register external node - counting
+resource "consul_node" "counting" {
+  name    = "counting"
+  address = "localhost"
+
+  meta = {
+    "external-node"  = "true"
+    "external-probe" = "true"
+  }
+}
+
+# Register external node - dashboard
+resource "consul_node" "dashboard" {
+  name    = "dashboard"
+  address = "localhost"
+
+  meta = {
+    "external-node"  = "true"
+    "external-probe" = "true"
+  }
+}
+
+# Register Counting Service
+resource "consul_service" "counting" {
+  name    = "counting-service"
+  node    = consul_node.counting.name
+  port    = 9001
+  tags    = ["counting"]
+
+  check {
+    check_id                          = "service:counting"
+    name                              = "Counting health check"
+    status                            = "passing"
+    http                              = "localhost:9001"
+    tls_skip_verify                   = false
+    method                            = "GET"
+    interval                          = "5s"
+    timeout                           = "1s"
+  }
+}
+
+# Register Dashboard Service
+resource "consul_service" "dashboard" {
+  name    = "dashboard-service"
+  node    = consul_node.dashboard.name
+  port    = 8080
+  tags    = ["dashboard"]
+
+  check {
+    check_id                          = "service:dashboard"
+    name                              = "Dashboard health check"
+    status                            = "passing"
+    http                              = "localhost:8080"
+    tls_skip_verify                   = false
+    method                            = "GET"
+    interval                          = "5s"
+    timeout                           = "1s"
+  }
+}
+
+# List all services
+data "consul_services" "dc1" {}
+
+output "consul_services_dc1" {
+    value = data.consul_services.dc1
+}
+
+
+# Exported Services Demo
+resource "consul_admin_partition" "ap1" {
+  name = "ap1"
+}
+
+resource "consul_config_entry_v2_exported_services" "counting" {
+  kind = "ExportedServices"
+  name = "exported-counting"
+  partition = "default"
+  partition_consumers = ["ap1"]
+  services = ["counting-service"]
+}
+
+resource "consul_config_entry_v2_exported_services" "dash" {
+  kind = "ExportedServices"
+  name = "exported-dash"
+  partition = "default"
+  partition_consumers = ["ap1"]
+  services = ["dashboard-service"]
+}
+
+resource "consul_admin_partition" "ap2" {
+  name = "ap2"
+}
+
+resource "consul_config_entry_v2_exported_services" "ns" {
+  kind = "NamespaceExportedServices"
+  name = "exported-ns"
+  namespace = "default"
+  partition = "default"
+  partition_consumers = ["ap2"]
+}
+
+resource "consul_admin_partition" "ap3" {
+  name = "ap3"
+}
+
+resource "consul_config_entry_v2_exported_services" "part" {
+  kind = "PartitionExportedServices"
+  name = "exported-part"
+  partition = "default"
+  partition_consumers = ["ap3"]
 }

--- a/consul-playground/server/Dockerfile
+++ b/consul-playground/server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM consul:latest
+FROM hashicorppreview/consul-enterprise:1.18-dev
 
 COPY . /etc/consul.d
 


### PR DESCRIPTION
Pre-reqs: 
1. Build the terraform provider locally and update your .terraformrc to replace hashicorp/consul with the path to your local terraform provider binary, [as described in the development overrides terraform docs](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
2. Put a file with a valid consul-enterprise license in the correct secrets file location specified in docker-compose.yml

Steps:

1. docker-compose up --detach
2. `docker exec -it consul-playground-consul-server-1-1 consul acl bootstrap`
3. Save the bootstrap token to use in main.tf, the Consul UI, and future CLI commands
4. terraform apply
5. Verify services are registered in the UI
6. Check config entry for the default partition to verify that all exported services components are present:
`docker exec -it consul-playground-consul-server-1-1 consul config read -token=b27a8f38-73f3-e29b-985d-d8f79c73b59c -kind exported-services -name default`

Add / delete resources to see updates in the config

Double check the consul and terraform provider versions before troubleshooting (at time of writing, one needs an unreleased 1.18-dev consul enterprise build and a dev build from the hashicorp/terraform-provider-consul main branch)

To make manual calls to update the V2 "partial config" resources via the Consul API on a local consul dev cluster, you can issue commands in the following format:
`curl -d '{"data": {"services": ["s1"], "consumers": [{"partition": "ap1"}]}}' -H "Content-Type: application/json" -X PUT http://localhost:8500/api/multicluster/v2/$KIND/$NAME`
Where: 
1. "consumers" may be of the type: partition, peer, or sameness_group
2. the URL path specifies a kind that is one of: exportedservices, namespaceexportedservices, or partitionexportedservices (only exportedservices may supply service names, and services must be successfully registered)
3. $NAME refers to the name of the V2 "partial config" resource
Examples:

`curl -d '{"data": {"services": ["s1"], "consumers": [{"partition": "ap1"}]}}' -H "Content-Type: application/json" -X PUT http://localhost:8500/api/multicluster/v2/exportedservices/expsvc1`

`curl -d '{"data": {"consumers": [{"sameness_group": "sg1"}]}}' -H "Content-Type: application/json" -X PUT http://localhost:8500/api/multicluster/v2/namespaceexportedservices/nsexpsvc1?namespace=ns1&partition=default`

`curl -d '{"data": {"consumers": [{"peer": "p1"}]}}' -H "Content-Type: application/json" -X PUT http://localhost:8500/api/multicluster/v2/partitionexportedservices/ptexpsvc1?partition=foo`

READ and DELETE methods also work to verify operations (with the same path and data omitted)
